### PR TITLE
Disable TypeScript declaration and source map generation

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "version": "1.1.0",
   "description": "Signal K Onvif Camera Interface",
   "main": "dist/index.js",
-  "types": "dist/index.d.ts",
   "files": [
     "dist/",
     "public/",

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,5 +1,9 @@
 {
   "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": false,
+    "sourceMap": false
+  },
   "include": [
     "index.ts",
     "lib/**/*.ts"


### PR DESCRIPTION
## Summary
This PR disables TypeScript declaration file and source map generation in the build configuration, and removes the TypeScript types export from package.json.

## Key Changes
- Added compiler options to `tsconfig.build.json` to disable `declaration` and `sourceMap` generation
- Removed the `types` field from `package.json` that pointed to the generated declaration file

## Details
These changes indicate a shift away from distributing TypeScript type definitions with the compiled output. The build will now produce only JavaScript files without accompanying `.d.ts` declaration files or `.js.map` source maps, reducing the build artifact size and simplifying the distribution package.

https://claude.ai/code/session_01KS5VniUEc6T48J7wkqhkNg