### PR TITLE
Guard WebSocket upgrade handling on non-server app.server and add tests

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -133,6 +133,14 @@ interface PluginApp {
   server?: AppServerLike | null;
 }
 
+function hasUpgradeListenerServer(server: PluginApp['server']): server is AppServerLike {
+  return Boolean(
+    server
+    && typeof server.on === 'function'
+    && typeof server.removeListener === 'function'
+  );
+}
+
 interface HttpRequestLike {
   query: UnknownRecord;
   url?: string;
@@ -443,11 +451,11 @@ module.exports = function createPlugin(app: PluginApp): PluginDefinition {
       wsServer.close();
       wsServer = null;
     }
-    if (upgradeHandler && app.server) {
+    if (upgradeHandler && hasUpgradeListenerServer(app.server)) {
       app.server.removeListener('upgrade', upgradeHandler);
       upgradeHandler = null;
     }
-    if (app.server) {
+    if (hasUpgradeListenerServer(app.server)) {
       // Use noServer mode so we don't interfere with SignalK's own
       // WebSocket server on the same HTTP server.  With the default
       // { server } option the ws library adds its own 'upgrade'
@@ -680,7 +688,7 @@ module.exports = function createPlugin(app: PluginApp): PluginDefinition {
     mjpegStreams.clear();
     closeActiveWsConnections();
 
-    if (upgradeHandler && app.server) {
+    if (upgradeHandler && hasUpgradeListenerServer(app.server)) {
       app.server.removeListener('upgrade', upgradeHandler);
       upgradeHandler = null;
     }

--- a/test/plugin.test.ts
+++ b/test/plugin.test.ts
@@ -203,6 +203,22 @@ describe('signalk-onvif-camera plugin', () => {
       expect(() => p.start(baseOptions)).not.toThrow();
       consoleSpy.mockRestore();
     });
+
+    test('should not throw when app.server does not implement EventEmitter methods', () => {
+      const appInvalidServer = { ...mockApp, server: {} };
+      jest.resetModules();
+      const createPlugin = require('../index') as CreatePlugin;
+      const p = createPlugin(appInvalidServer);
+      expect(() => p.start(baseOptions)).not.toThrow();
+    });
+
+    test('should not throw when app.server is a non-server function value', () => {
+      const appFunctionServer = { ...mockApp, server: (() => {}) };
+      jest.resetModules();
+      const createPlugin = require('../index') as CreatePlugin;
+      const p = createPlugin(appFunctionServer);
+      expect(() => p.start(baseOptions)).not.toThrow();
+    });
   });
 
   // ── plugin.stop() ───────────────────────────────────────────────────────────

--- a/test/test-types.ts
+++ b/test/test-types.ts
@@ -45,7 +45,7 @@ export interface MockApp {
   debug: jest.Mock;
   handleMessage: jest.Mock;
   get: jest.Mock;
-  server: EventEmitter | null;
+  server: unknown | null;
   getDataDirPath: jest.Mock<string, []>;
   securityStrategy?: SecurityStrategy;
 }


### PR DESCRIPTION
### Motivation

- Prevent runtime errors when `app.server` is absent or does not implement EventEmitter-like `on`/`removeListener` methods so the plugin can start/stop safely in varied SignalK host environments.
- Tighten TypeScript test types to allow non-EventEmitter `server` shapes used in tests.

### Description

- Add a type guard `hasUpgradeListenerServer(server)` that checks for `on` and `removeListener` functions and use it before calling those methods or attaching a WebSocket `noServer` handler.
- Replace direct `app.server` truthiness checks with `hasUpgradeListenerServer(app.server)` where upgrade listeners are added/removed to avoid calling methods on non-server values.
- Update tests to cover cases where `app.server` is `null`, an empty object, or a function, ensuring `plugin.start()` does not throw in those situations.
- Relax the test `MockApp` type for `server` from `EventEmitter | null` to `unknown | null` to accommodate non-EventEmitter test fixtures.

### Testing

- Ran the automated test suite with `npm test` (Jest) including the new tests in `test/plugin.test.ts`, and all tests passed.
- Existing tests around `plugin.start()`/`plugin.stop()` and MJPEG/WebSocket shutdown behavior were re-run and remained green.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc153fd344832abb262e7618ac6355)