### PR TITLE
Add type guard for app.server EventEmitter methods

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -133,6 +133,14 @@ interface PluginApp {
   server?: AppServerLike | null;
 }
 
+function hasUpgradeListenerServer(server: PluginApp['server']): server is AppServerLike {
+  return Boolean(
+    server
+    && typeof server.on === 'function'
+    && typeof server.removeListener === 'function'
+  );
+}
+
 interface HttpRequestLike {
   query: UnknownRecord;
   url?: string;
@@ -443,11 +451,11 @@ module.exports = function createPlugin(app: PluginApp): PluginDefinition {
       wsServer.close();
       wsServer = null;
     }
-    if (upgradeHandler && app.server) {
+    if (upgradeHandler && hasUpgradeListenerServer(app.server)) {
       app.server.removeListener('upgrade', upgradeHandler);
       upgradeHandler = null;
     }
-    if (app.server) {
+    if (hasUpgradeListenerServer(app.server)) {
       // Use noServer mode so we don't interfere with SignalK's own
       // WebSocket server on the same HTTP server.  With the default
       // { server } option the ws library adds its own 'upgrade'
@@ -680,7 +688,7 @@ module.exports = function createPlugin(app: PluginApp): PluginDefinition {
     mjpegStreams.clear();
     closeActiveWsConnections();
 
-    if (upgradeHandler && app.server) {
+    if (upgradeHandler && hasUpgradeListenerServer(app.server)) {
       app.server.removeListener('upgrade', upgradeHandler);
       upgradeHandler = null;
     }

--- a/test/plugin.test.ts
+++ b/test/plugin.test.ts
@@ -203,6 +203,22 @@ describe('signalk-onvif-camera plugin', () => {
       expect(() => p.start(baseOptions)).not.toThrow();
       consoleSpy.mockRestore();
     });
+
+    test('should not throw when app.server does not implement EventEmitter methods', () => {
+      const appInvalidServer = { ...mockApp, server: {} };
+      jest.resetModules();
+      const createPlugin = require('../index') as CreatePlugin;
+      const p = createPlugin(appInvalidServer);
+      expect(() => p.start(baseOptions)).not.toThrow();
+    });
+
+    test('should not throw when app.server is a non-server function value', () => {
+      const appFunctionServer = { ...mockApp, server: (() => {}) };
+      jest.resetModules();
+      const createPlugin = require('../index') as CreatePlugin;
+      const p = createPlugin(appFunctionServer);
+      expect(() => p.start(baseOptions)).not.toThrow();
+    });
   });
 
   // ── plugin.stop() ───────────────────────────────────────────────────────────

--- a/test/test-types.ts
+++ b/test/test-types.ts
@@ -45,7 +45,7 @@ export interface MockApp {
   debug: jest.Mock;
   handleMessage: jest.Mock;
   get: jest.Mock;
-  server: EventEmitter | null;
+  server: unknown | null;
   getDataDirPath: jest.Mock<string, []>;
   securityStrategy?: SecurityStrategy;
 }


### PR DESCRIPTION
## Summary
This PR adds defensive type checking for the `app.server` object to ensure it implements the required EventEmitter methods (`on` and `removeListener`) before attempting to use them. This prevents runtime errors when `app.server` is an unexpected type or lacks the necessary interface.

## Key Changes
- Added `hasUpgradeListenerServer()` type guard function that validates `app.server` has both `on` and `removeListener` methods before treating it as an `AppServerLike` object
- Updated three locations where `app.server` is used to call the type guard:
  - In the `start()` method when setting up the upgrade listener
  - In the `start()` method when configuring the WebSocket server
  - In the `stop()` method when removing the upgrade listener
- Updated test type definitions to allow `app.server` to be `unknown` instead of strictly `EventEmitter | null`
- Added two new test cases to verify the plugin doesn't throw when:
  - `app.server` is an empty object without EventEmitter methods
  - `app.server` is a function value instead of a server object

## Implementation Details
The type guard uses a simple boolean check to verify both required methods exist and are functions, providing a safe way to narrow the type before accessing EventEmitter-specific functionality. This approach prevents potential runtime errors in environments where `app.server` may not be a proper HTTP server instance.

https://claude.ai/code/session_01JBaPJpJRoeUnaf8zzhrPx8